### PR TITLE
Updated TypeProvider to support different method/function parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ $f->foo('', '<caret>')
 ```php
 /** @var $f \\FooClass */
 $f->foo('date_time')->format<caret>
+$f->bar('', date_time')->format<caret>
 ```
 
 ```javascript
@@ -175,6 +176,12 @@ $f->foo('date_time')->format<caret>
         {
           "class": "FooClass",
           "method": "foo",
+          "type": "type"
+        },
+        {
+          "class": "FooClass",
+          "method": "bar",
+          "index": 1,
           "type": "type"
         }
       ]

--- a/tests/de/espend/idea/php/toolbox/tests/type/PhpToolboxTypeProviderTest.java
+++ b/tests/de/espend/idea/php/toolbox/tests/type/PhpToolboxTypeProviderTest.java
@@ -31,6 +31,13 @@ public class PhpToolboxTypeProviderTest extends SymfonyLightCodeInsightFixtureTe
             PlatformPatterns.psiElement(Method.class).withName("format")
         );
 
+        // Same method name but different class and parameter index
+        assertPhpReferenceResolveTo(PhpFileType.INSTANCE, "<?php\n" +
+            "/** @var $f \\Foo\\Baz */\n" +
+            "$f->foo('', 'datetime')->for<caret>mat()",
+            PlatformPatterns.psiElement(Method.class).withName("format")
+        );
+
         assertPhpReferenceResolveTo(PhpFileType.INSTANCE, "<?php\n" +
             "/** @var $f \\Foo\\Bar */\n" +
             "$f->foo(\\Foo\\Bar::DATETIME)->for<caret>mat()",
@@ -40,12 +47,12 @@ public class PhpToolboxTypeProviderTest extends SymfonyLightCodeInsightFixtureTe
 
     public void testPhpTypeForFunctions() {
         assertPhpReferenceResolveTo(PhpFileType.INSTANCE, "<?php\n" +
-            "car('datetime')->for<caret>mat()",
+            "car('', 'datetime')->for<caret>mat()",
             PlatformPatterns.psiElement(Method.class).withName("format")
         );
 
         assertPhpReferenceResolveTo(PhpFileType.INSTANCE, "<?php\n" +
-            "car(\\Foo\\Bar::DATETIME)->for<caret>mat()",
+            "car('', \\Foo\\Bar::DATETIME)->for<caret>mat()",
             PlatformPatterns.psiElement(Method.class).withName("format")
         );
     }

--- a/tests/de/espend/idea/php/toolbox/tests/type/fixtures/classes.php
+++ b/tests/de/espend/idea/php/toolbox/tests/type/fixtures/classes.php
@@ -6,8 +6,12 @@ namespace Foo
     {
         const DATETIME = 'datetime';
 
-        public function foo() {}
+        public function foo($class) {}
         public static function app() {}
+    }
+    class Baz
+    {
+        public function foo($_, $class) {}
     }
 }
 

--- a/tests/de/espend/idea/php/toolbox/tests/type/fixtures/ide-toolbox.metadata.json
+++ b/tests/de/espend/idea/php/toolbox/tests/type/fixtures/ide-toolbox.metadata.json
@@ -8,12 +8,19 @@
           "type": "type"
         },
         {
+          "class": "Foo\\Baz",
+          "method": "foo",
+          "index": 1,
+          "type": "type"
+        },
+        {
           "class": "Foo\\Bar",
           "method": "app",
           "type": "type"
         },
         {
           "function": "car",
+          "index": 1,
           "type": "type"
         }
       ],


### PR DESCRIPTION
Updated TypeProvider to support different method/function parameters besides the first with "index" parameter.

Fixes #20 

This is my first PR for an idea plugin, so advice is very much appreciated.

It seems like when creating the signature, we don't know the class name. So we need to add the types of all indexes that could be needed and match it later in `getBySignature`. I did that by concatenating each index and its type and joining those with the `trimKey` and then joining that to the `refSignature` with two of the `trimKey` chars. This breaks if the index wanted is greater than 9 but I figured that was an ok risk. I'm happy to change it to another kind of pattern, I'm just not sure what I can use to delineate on here.

I don't know what kind of BC we are trying to provide here. This does break BC for `PhpTypeProviderUtil` if it was called directly. Nothing has changed with `PhpToolboxTypeProviderInterface` which I figure is the one everyone is using.