### PR TITLE
Allow resolving parameter types from new expressions. `foo(new Bar())`

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ $f->foo('', '<caret>')
 ```php
 /** @var $f \\FooClass */
 $f->foo('date_time')->format<caret>
-$f->bar('', date_time')->format<caret>
+$f->foo(DateTime::class)->format<caret>
+$f->foo(new DateTime())->format<caret>
+$f->bar('', 'date_time')->format<caret>
 ```
 
 ```javascript

--- a/src/de/espend/idea/php/toolbox/type/PhpToolboxTypeProvider.java
+++ b/src/de/espend/idea/php/toolbox/type/PhpToolboxTypeProvider.java
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 import static com.intellij.openapi.util.Pair.pair;
-import static java.util.stream.Collectors.toMap;
 
 /**
  * @author Daniel Espendiller <daniel@espendiller.net>

--- a/src/de/espend/idea/php/toolbox/type/utils/PhpTypeProviderUtil.java
+++ b/src/de/espend/idea/php/toolbox/type/utils/PhpTypeProviderUtil.java
@@ -63,6 +63,21 @@ public class PhpTypeProviderUtil {
 
                 parameterSignatures.put(parameterIndex, signature);
             }
+
+            // new Entity()
+            if (parameter instanceof NewExpression) {
+                ClassReference classReference = ((NewExpression) parameter).getClassReference();
+                if (classReference == null) {
+                    continue;
+                }
+                String signature = classReference.getSignature();
+                if (StringUtil.isEmpty(signature)) {
+                    continue;
+                }
+                signature = "#K" + signature + ".class";
+
+                parameterSignatures.put(parameterIndex, signature);
+            }
         }
 
         if (parameterSignatures.isEmpty()) {

--- a/tests/de/espend/idea/php/toolbox/tests/type/PhpToolboxTypeProviderTest.java
+++ b/tests/de/espend/idea/php/toolbox/tests/type/PhpToolboxTypeProviderTest.java
@@ -85,5 +85,9 @@ public class PhpToolboxTypeProviderTest extends SymfonyLightCodeInsightFixtureTe
                 "clazz('\\\\DateTime')->for<caret>mat()",
             PlatformPatterns.psiElement(Method.class).withName("format")
         );
+        assertPhpReferenceResolveTo(PhpFileType.INSTANCE, "<?php\n" +
+                "clazz(new DateTime())->for<caret>mat()",
+            PlatformPatterns.psiElement(Method.class).withName("format")
+        );
     }
 }


### PR DESCRIPTION
A real world example of this is with Flysystem. You pass in a handler object to [ `Filesystem::get()`](https://github.com/thephpleague/flysystem/blob/master/src/Filesystem.php#L359-L372) which is then populated and returned.
```php
$file = $filesystem->get('foo.txt', new File());
```

---

On a side note, I'm pretty confused on what's allowed in `PhpTypeProvider3#getType`.

Can you use an method of the (sub)element given or are you restricted to only certain ones?

Like `PhpReference` has `getFQN`, `resolveLocalType`, `resolveLocalType`, `resolveGlobal`, `getType`. Are all of these ok to use? or only some? Do none of these need the `PhpIndex`?